### PR TITLE
Parser now excludes PvP area changing the zone name

### DIFF
--- a/EverQuestDPSPlugin/Properties/AssemblyInfo.cs
+++ b/EverQuestDPSPlugin/Properties/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.5.3.*")]
+[assembly: AssemblyVersion("2.5.4.*")]
 [assembly: InternalsVisibleTo("EQDPSPluginUnitTests")]

--- a/EverQuestDPSPlugin/Properties/PluginRegex.Designer.cs
+++ b/EverQuestDPSPlugin/Properties/PluginRegex.Designer.cs
@@ -601,7 +601,7 @@ namespace EverQuestDPS.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have entered (?!.*an area where Bind Affinity is allowed)(?!.*an area where levitation effects do not function)(?!.*the Drunken Monkey stance adequately)(?&lt;zoneName&gt;.*)..
+        ///   Looks up a localized string similar to You have entered ((?&lt;zoneName&gt;.*)|(?!((the Drunken Monkey stance adequately)|(an area where levitation effects do not function)|(an area where Bind Affinity is allowed)|(an Arena (PvP) area))))..
         /// </summary>
         internal static string zoneChange {
             get {

--- a/EverQuestDPSPlugin/Properties/PluginRegex.resx
+++ b/EverQuestDPSPlugin/Properties/PluginRegex.resx
@@ -175,7 +175,7 @@
     <value>(?&lt;Unknown&gt;(u|U)nknown)</value>
   </data>
   <data name="zoneChange" xml:space="preserve">
-    <value>You have entered (?!.*an area where Bind Affinity is allowed)(?!.*an area where levitation effects do not function)(?!.*the Drunken Monkey stance adequately)(?&lt;zoneName&gt;.*).</value>
+    <value>You have entered ((?&lt;zoneName&gt;.*)|(?!((the Drunken Monkey stance adequately)|(an area where levitation effects do not function)|(an area where Bind Affinity is allowed)|(an Arena (PvP) area)))).</value>
   </data>
   <data name="attackTypes" xml:space="preserve">
     <value>backstab|throw|pierce|gore|crush|slash|hit|kick|slam|bash|shoot|strike|bite|grab|punch|scratch|rake|swipe|claw|maul|smash|frenzies on|frenzy</value>


### PR DESCRIPTION
Parser now excludes PvP area changing the zone name